### PR TITLE
use custom errors to save gas on deployment

### DIFF
--- a/test/ERC721S.approvalsandtransfers.test.js
+++ b/test/ERC721S.approvalsandtransfers.test.js
@@ -1,265 +1,259 @@
-const { expect } = require("chai");
-const { ethers } = require("hardhat");
-
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
 
 // transferFrom
 // safeTransferFrom
-describe("ERC721S Approvals and Transfers", function () {
-    let contract;
-    let deployer;
-    let minter;
-    let approved;
-    let operator;
+describe('ERC721S Approvals and Transfers', function () {
+  let contract;
+  let deployer;
+  let minter;
+  let approved;
+  let operator;
 
-    beforeEach(async () => {
-        const ERC721SImpl = await ethers.getContractFactory("ERC721SImpl");
-        contract = await ERC721SImpl.deploy("ERC721Impl", "IMPL");
-        [deployer, minter, approved, operator, EOAReceiver] = await ethers.getSigners();
+  beforeEach(async () => {
+    const ERC721SImpl = await ethers.getContractFactory('ERC721SImpl');
+    contract = await ERC721SImpl.deploy('ERC721Impl', 'IMPL');
+    [deployer, minter, approved, operator, EOAReceiver] = await ethers.getSigners();
+  });
+
+  describe('Approvals', function () {
+    describe('getApproved', function () {
+      it('returns address that has been approved', async () => {
+        await contract.connect(minter).mint(1);
+        await contract.connect(minter).approve(approved.address, 1);
+
+        expect(await contract.getApproved(1)).to.be.equal(approved.address);
+      });
+
+      it('returns address(0) after minting', async () => {
+        await contract.connect(minter).mint(1);
+
+        expect(await contract.getApproved(1)).to.be.equal(ethers.constants.AddressZero);
+      });
+
+      it('reverts if token does not exist', async () => {
+        await expect(contract.getApproved(0)).to.be.reverted;
+
+        await expect(contract.getApproved(1)).to.be.reverted;
+      });
     });
 
-    describe("Approvals", function () {
-        describe("getApproved", function () {
-            it("returns address that has been approved", async () => {
-                await contract.connect(minter).mint(1);
-                await contract.connect(minter).approve(approved.address, 1);
+    describe('isApprovedForAll', function () {
+      it("returns true if operator is in msg.sender's approvals list and marked as approved", async () => {
+        contract.connect(minter).setApprovalForAll(operator.address, true);
 
-                expect(await contract.getApproved(1))
-                    .to.be.equal(approved.address);
-            });
+        expect(await contract.isApprovedForAll(minter.address, operator.address)).to.be.equal(true);
+      });
 
-            it("returns address(0) after minting", async () => {
-                await contract.connect(minter).mint(1);
+      it("returns false if operator is in msg.sender's approvals list and marked as not approved", async () => {
+        contract.connect(minter).setApprovalForAll(operator.address, false);
 
-                expect(await contract.getApproved(1))
-                    .to.be.equal(ethers.constants.AddressZero);
-            });
+        expect(await contract.isApprovedForAll(minter.address, operator.address)).to.be.equal(false);
+      });
 
-            it("reverts if token does not exist", async () => {
-                await expect(contract.getApproved(0))
-                    .to.be.reverted;
-
-                await expect(contract.getApproved(1))
-                    .to.be.reverted;
-            });
-        });
-
-        describe("isApprovedForAll", function () {
-            it("returns true if operator is in msg.sender's approvals list and marked as approved", async () => {
-                contract.connect(minter).setApprovalForAll(operator.address, true);
-
-                expect(await contract.isApprovedForAll(minter.address, operator.address))
-                    .to.be.equal(true);
-            });
-
-            it("returns false if operator is in msg.sender's approvals list and marked as not approved", async () => {
-                contract.connect(minter).setApprovalForAll(operator.address, false);
-
-                expect(await contract.isApprovedForAll(minter.address, operator.address))
-                    .to.be.equal(false);
-            });
-
-            it("returns false if operator is in not msg.sender's approvals list", async () => {
-                expect(await contract.isApprovedForAll(minter.address, operator.address))
-                    .to.be.equal(false);
-            });
-        });
-
-        describe("setApprovalForAll", function () {
-            it("emits an ApprovalForAll event when set", async () => {
-                await expect(contract.connect(minter).setApprovalForAll(operator.address, true))
-                    .to.emit(contract, "ApprovalForAll")
-                    .withArgs(minter.address, operator.address, true);
-            });
-
-            it("can have multiple operators in approval for all list", async () => {
-                await contract.connect(minter).setApprovalForAll(approved.address, true);
-                await contract.connect(minter).setApprovalForAll(operator.address, true);
-
-                expect(await contract.isApprovedForAll(minter.address, approved.address))
-                    .to.be.equal(true);
-                expect(await contract.isApprovedForAll(minter.address, operator.address))
-                    .to.be.equal(true);
-            });
-        });
-
-        describe("approve", function () {
-            it("sets approved address if caller is owner or is in owner's approved list", async () => {
-                await contract.connect(minter).mint(1);
-
-                await contract.connect(minter).approve(approved.address, 1);
-
-                expect(await contract.getApproved(1))
-                    .to.be.equal(approved.address);
-
-                await contract.connect(minter).setApprovalForAll(operator.address, true);
-
-                expect(await contract.getApproved(1))
-                    .to.be.equal(approved.address);
-
-                await contract.connect(operator).approve(operator.address, 1);
-
-                expect(await contract.getApproved(1))
-                    .to.be.equal(operator.address);
-            });
-
-            it("emits an approval event when set", async () => {
-                await contract.connect(minter).mint(1);
-
-                await expect(contract.connect(minter).approve(operator.address, 1))
-                    .to.emit(contract, "Approval")
-                    .withArgs(minter.address, operator.address, 1);
-            });
-
-            it("reverts if owner tries to set approved to themselves", async () => {
-                await contract.connect(minter).mint(1);
-                await expect(contract.connect(minter).approve(minter.address, 1))
-                    .to.be.revertedWith("ERC721: approval to current owner");
-            });
-
-            it("reverts if approve caller is not owner of token or in owner's approved list", async () => {
-                await contract.connect(minter).mint(1);
-                await expect(contract.connect(approved).approve(approved.address, 1))
-                    .to.be.revertedWith("ERC721: approve caller is not owner nor approved for all");
-            });
-        });
+      it("returns false if operator is in not msg.sender's approvals list", async () => {
+        expect(await contract.isApprovedForAll(minter.address, operator.address)).to.be.equal(false);
+      });
     });
 
-    describe("Transfers", function () {
-        describe("transferFrom", function () {
-            it("reverts if sender is not approved, in approval for all list, or owner of token", async () => {
-                await contract.connect(minter).mint(1);
-                await expect(contract.connect(operator).transferFrom(minter.address, operator.address, 1))
-                    .to.be.revertedWith("ERC721: transfer caller is not owner nor approved");
-            });
+    describe('setApprovalForAll', function () {
+      it('emits an ApprovalForAll event when set', async () => {
+        await expect(contract.connect(minter).setApprovalForAll(operator.address, true))
+          .to.emit(contract, 'ApprovalForAll')
+          .withArgs(minter.address, operator.address, true);
+      });
 
-            it("transfers to 'to' address if sender is owner, approved, or in approval for all list", async () => {
-                await contract.connect(minter).mint(3);
+      it('can have multiple operators in approval for all list', async () => {
+        await contract.connect(minter).setApprovalForAll(approved.address, true);
+        await contract.connect(minter).setApprovalForAll(operator.address, true);
 
-                await contract.connect(minter).setApprovalForAll(operator.address, true);
-                await contract.connect(minter).approve(approved.address, 3);
-
-                await contract.connect(minter).transferFrom(minter.address, EOAReceiver.address, 1);
-                await contract.connect(operator).transferFrom(minter.address, EOAReceiver.address, 2);
-                await contract.connect(approved).transferFrom(minter.address, EOAReceiver.address, 3);
-
-                expect(await contract.balanceOf(EOAReceiver.address)).to.be.equal(3);
-                expect(await contract.ownerOf(1)).to.be.equal(EOAReceiver.address);
-                expect(await contract.ownerOf(2)).to.be.equal(EOAReceiver.address);
-                expect(await contract.ownerOf(3)).to.be.equal(EOAReceiver.address);
-
-            });
-
-            it("clear approved and sets new owner for token id and updates balances", async () => {
-                await contract.connect(minter).mint(3);
-
-                await contract.connect(minter).approve(approved.address, 3);
-
-                expect(await contract.balanceOf(minter.address))
-                    .to.be.equal(3);
-                expect(await contract.getApproved(3))
-                    .to.be.equal(approved.address);
-
-                await contract.connect(minter).transferFrom(minter.address, EOAReceiver.address, 3);
-
-                expect(await contract.balanceOf(minter.address))
-                    .to.be.equal(2);
-                expect(await contract.balanceOf(EOAReceiver.address))
-                    .to.be.equal(1);
-                expect(await contract.getApproved(3))
-                    .to.be.equal(ethers.constants.AddressZero);
-
-            });
-
-            it("emits Transfer event", async () => {
-                await contract.connect(minter).mint(3);
-                await expect(contract.connect(minter).transferFrom(minter.address, EOAReceiver.address, 3))
-                    .to.emit(contract, "Transfer")
-                    .withArgs(minter.address, EOAReceiver.address, 3);
-            });
-        });
-        describe("safeTransferFrom", function () {
-            it("reverts if sender is not approved, in approval for all list, or owner of token", async () => {
-                await contract.connect(minter).mint(1);
-                await expect(contract.connect(operator)["safeTransferFrom(address,address,uint256)"](minter.address, operator.address, 1))
-                    .to.be.revertedWith("ERC721: transfer caller is not owner nor approved");
-            });
-
-            it("transfers to 'to' address if sender is owner, approved, or in approval for all list", async () => {
-                await contract.connect(minter).mint(3);
-
-                await contract.connect(minter).setApprovalForAll(operator.address, true);
-                await contract.connect(minter).approve(approved.address, 3);
-
-                await contract.connect(minter)["safeTransferFrom(address,address,uint256)"](minter.address, EOAReceiver.address, 1);
-                await contract.connect(operator)["safeTransferFrom(address,address,uint256)"](minter.address, EOAReceiver.address, 2);
-                await contract.connect(approved)["safeTransferFrom(address,address,uint256)"](minter.address, EOAReceiver.address, 3);
-
-                expect(await contract.balanceOf(EOAReceiver.address)).to.be.equal(3);
-                expect(await contract.ownerOf(1)).to.be.equal(EOAReceiver.address);
-                expect(await contract.ownerOf(2)).to.be.equal(EOAReceiver.address);
-                expect(await contract.ownerOf(3)).to.be.equal(EOAReceiver.address);
-
-            });
-            it('successfully transfers to a contract address if receiving contract handles onERC721Received correctly', async () => {
-                const ERC721ValidReceiverStub = await ethers.getContractFactory("ERC721ValidReceiverStub");
-                receiverStub = await ERC721ValidReceiverStub.deploy();
-
-                await contract.connect(minter).mint(1);
-
-                await expect(contract.connect(minter)["safeTransferFrom(address,address,uint256)"](minter.address, receiverStub.address, 1))
-                    .to.emit(receiverStub, "Received")
-                    .withArgs(minter.address, minter.address, 1, ethers.utils.toUtf8Bytes(""));
-            });
-
-            it("reverts if receiving contract does not have a valid onERC721Received function", async () => {
-                const ERC721EmptyReceiverStub = await ethers.getContractFactory("ERC721EmptyReceiverStub");
-                receiverStub = await ERC721EmptyReceiverStub.deploy();
-
-                await contract.connect(minter).mint(1);
-
-                await expect(contract.connect(minter)["safeTransferFrom(address,address,uint256)"](minter.address, receiverStub.address, 1))
-                    .to.be.revertedWith("ERC721: transfer to non ERC721Receiver implementer");
-            });
-
-            it("reverts if receiving contract reverts", async () => {
-                const ERC721RevertReceiverStub = await ethers.getContractFactory("ERC721RevertReceiverStub");
-                receiverStub = await ERC721RevertReceiverStub.deploy("");
-
-                await contract.connect(minter).mint(1);
-
-                await expect(contract.connect(minter)["safeTransferFrom(address,address,uint256)"](minter.address, receiverStub.address, 1))
-                    .to.be.reverted;
-            });
-
-            it("reverts with message if receiving contract reverts with message", async () => {
-                const ERC721RevertReceiverStub = await ethers.getContractFactory("ERC721RevertReceiverStub");
-                receiverStub = await ERC721RevertReceiverStub.deploy("revert message");
-
-                await contract.connect(minter).mint(1);
-
-                await expect(contract.connect(minter)["safeTransferFrom(address,address,uint256)"](minter.address, receiverStub.address, 1))
-                    .to.be.revertedWith("revert message");
-            });
-
-            it("reverts if receiving contract returns an invalid response", async () => {
-                const ERC721InvalidReceiverStub = await ethers.getContractFactory("ERC721InvalidReceiverStub");
-                receiverStub = await ERC721InvalidReceiverStub.deploy();
-
-                await contract.connect(minter).mint(1);
-
-                await expect(contract.connect(minter)["safeTransferFrom(address,address,uint256)"](minter.address, receiverStub.address, 1))
-                    .to.be.reverted;
-            });
-
-            it("reverts if receiving contract panics", async () => {
-                const ERC721PanicReceiverStub = await ethers.getContractFactory("ERC721PanicReceiverStub");
-                receiverStub = await ERC721PanicReceiverStub.deploy();
-
-                await contract.connect(minter).mint(1);
-
-                await expect(contract.connect(minter)["safeTransferFrom(address,address,uint256)"](minter.address, receiverStub.address, 1))
-                    .to.be.reverted;
-            });
-        });
+        expect(await contract.isApprovedForAll(minter.address, approved.address)).to.be.equal(true);
+        expect(await contract.isApprovedForAll(minter.address, operator.address)).to.be.equal(true);
+      });
     });
+
+    describe('approve', function () {
+      it("sets approved address if caller is owner or is in owner's approved list", async () => {
+        await contract.connect(minter).mint(1);
+
+        await contract.connect(minter).approve(approved.address, 1);
+
+        expect(await contract.getApproved(1)).to.be.equal(approved.address);
+
+        await contract.connect(minter).setApprovalForAll(operator.address, true);
+
+        expect(await contract.getApproved(1)).to.be.equal(approved.address);
+
+        await contract.connect(operator).approve(operator.address, 1);
+
+        expect(await contract.getApproved(1)).to.be.equal(operator.address);
+      });
+
+      it('emits an approval event when set', async () => {
+        await contract.connect(minter).mint(1);
+
+        await expect(contract.connect(minter).approve(operator.address, 1))
+          .to.emit(contract, 'Approval')
+          .withArgs(minter.address, operator.address, 1);
+      });
+
+      it('reverts if owner tries to set approved to themselves', async () => {
+        await contract.connect(minter).mint(1);
+        await expect(contract.connect(minter).approve(minter.address, 1)).to.be.revertedWith('ApprovalToCurrentOwner');
+      });
+
+      it("reverts if approve caller is not owner of token or in owner's approved list", async () => {
+        await contract.connect(minter).mint(1);
+        await expect(contract.connect(approved).approve(approved.address, 1)).to.be.revertedWith(
+          'ApproveCallerIsNotOwnerNorApprovedForAll'
+        );
+      });
+    });
+  });
+
+  describe('Transfers', function () {
+    describe('transferFrom', function () {
+      it('reverts if sender is not approved, in approval for all list, or owner of token', async () => {
+        await contract.connect(minter).mint(1);
+        await expect(contract.connect(operator).transferFrom(minter.address, operator.address, 1)).to.be.revertedWith(
+          'TransferCallerIsNotOwnerNorApproved'
+        );
+      });
+
+      it("transfers to 'to' address if sender is owner, approved, or in approval for all list", async () => {
+        await contract.connect(minter).mint(3);
+
+        await contract.connect(minter).setApprovalForAll(operator.address, true);
+        await contract.connect(minter).approve(approved.address, 3);
+
+        await contract.connect(minter).transferFrom(minter.address, EOAReceiver.address, 1);
+        await contract.connect(operator).transferFrom(minter.address, EOAReceiver.address, 2);
+        await contract.connect(approved).transferFrom(minter.address, EOAReceiver.address, 3);
+
+        expect(await contract.balanceOf(EOAReceiver.address)).to.be.equal(3);
+        expect(await contract.ownerOf(1)).to.be.equal(EOAReceiver.address);
+        expect(await contract.ownerOf(2)).to.be.equal(EOAReceiver.address);
+        expect(await contract.ownerOf(3)).to.be.equal(EOAReceiver.address);
+      });
+
+      it('clear approved and sets new owner for token id and updates balances', async () => {
+        await contract.connect(minter).mint(3);
+
+        await contract.connect(minter).approve(approved.address, 3);
+
+        expect(await contract.balanceOf(minter.address)).to.be.equal(3);
+        expect(await contract.getApproved(3)).to.be.equal(approved.address);
+
+        await contract.connect(minter).transferFrom(minter.address, EOAReceiver.address, 3);
+
+        expect(await contract.balanceOf(minter.address)).to.be.equal(2);
+        expect(await contract.balanceOf(EOAReceiver.address)).to.be.equal(1);
+        expect(await contract.getApproved(3)).to.be.equal(ethers.constants.AddressZero);
+      });
+
+      it('emits Transfer event', async () => {
+        await contract.connect(minter).mint(3);
+        await expect(contract.connect(minter).transferFrom(minter.address, EOAReceiver.address, 3))
+          .to.emit(contract, 'Transfer')
+          .withArgs(minter.address, EOAReceiver.address, 3);
+      });
+    });
+    describe('safeTransferFrom', function () {
+      it('reverts if sender is not approved, in approval for all list, or owner of token', async () => {
+        await contract.connect(minter).mint(1);
+        await expect(
+          contract.connect(operator)['safeTransferFrom(address,address,uint256)'](minter.address, operator.address, 1)
+        ).to.be.revertedWith('TransferCallerIsNotOwnerNorApproved');
+      });
+
+      it("transfers to 'to' address if sender is owner, approved, or in approval for all list", async () => {
+        await contract.connect(minter).mint(3);
+
+        await contract.connect(minter).setApprovalForAll(operator.address, true);
+        await contract.connect(minter).approve(approved.address, 3);
+
+        await contract
+          .connect(minter)
+          ['safeTransferFrom(address,address,uint256)'](minter.address, EOAReceiver.address, 1);
+        await contract
+          .connect(operator)
+          ['safeTransferFrom(address,address,uint256)'](minter.address, EOAReceiver.address, 2);
+        await contract
+          .connect(approved)
+          ['safeTransferFrom(address,address,uint256)'](minter.address, EOAReceiver.address, 3);
+
+        expect(await contract.balanceOf(EOAReceiver.address)).to.be.equal(3);
+        expect(await contract.ownerOf(1)).to.be.equal(EOAReceiver.address);
+        expect(await contract.ownerOf(2)).to.be.equal(EOAReceiver.address);
+        expect(await contract.ownerOf(3)).to.be.equal(EOAReceiver.address);
+      });
+      it('successfully transfers to a contract address if receiving contract handles onERC721Received correctly', async () => {
+        const ERC721ValidReceiverStub = await ethers.getContractFactory('ERC721ValidReceiverStub');
+        receiverStub = await ERC721ValidReceiverStub.deploy();
+
+        await contract.connect(minter).mint(1);
+
+        await expect(
+          contract.connect(minter)['safeTransferFrom(address,address,uint256)'](minter.address, receiverStub.address, 1)
+        )
+          .to.emit(receiverStub, 'Received')
+          .withArgs(minter.address, minter.address, 1, ethers.utils.toUtf8Bytes(''));
+      });
+
+      it('reverts if receiving contract does not have a valid onERC721Received function', async () => {
+        const ERC721EmptyReceiverStub = await ethers.getContractFactory('ERC721EmptyReceiverStub');
+        receiverStub = await ERC721EmptyReceiverStub.deploy();
+
+        await contract.connect(minter).mint(1);
+
+        await expect(
+          contract.connect(minter)['safeTransferFrom(address,address,uint256)'](minter.address, receiverStub.address, 1)
+        ).to.be.revertedWith('TransferToNonERC721ReceiverImplementer');
+      });
+
+      it('reverts if receiving contract reverts', async () => {
+        const ERC721RevertReceiverStub = await ethers.getContractFactory('ERC721RevertReceiverStub');
+        receiverStub = await ERC721RevertReceiverStub.deploy('');
+
+        await contract.connect(minter).mint(1);
+
+        await expect(
+          contract.connect(minter)['safeTransferFrom(address,address,uint256)'](minter.address, receiverStub.address, 1)
+        ).to.be.reverted;
+      });
+
+      it('reverts with message if receiving contract reverts with message', async () => {
+        const ERC721RevertReceiverStub = await ethers.getContractFactory('ERC721RevertReceiverStub');
+        receiverStub = await ERC721RevertReceiverStub.deploy('revert message');
+
+        await contract.connect(minter).mint(1);
+
+        await expect(
+          contract.connect(minter)['safeTransferFrom(address,address,uint256)'](minter.address, receiverStub.address, 1)
+        ).to.be.revertedWith('revert message');
+      });
+
+      it('reverts if receiving contract returns an invalid response', async () => {
+        const ERC721InvalidReceiverStub = await ethers.getContractFactory('ERC721InvalidReceiverStub');
+        receiverStub = await ERC721InvalidReceiverStub.deploy();
+
+        await contract.connect(minter).mint(1);
+
+        await expect(
+          contract.connect(minter)['safeTransferFrom(address,address,uint256)'](minter.address, receiverStub.address, 1)
+        ).to.be.reverted;
+      });
+
+      it('reverts if receiving contract panics', async () => {
+        const ERC721PanicReceiverStub = await ethers.getContractFactory('ERC721PanicReceiverStub');
+        receiverStub = await ERC721PanicReceiverStub.deploy();
+
+        await contract.connect(minter).mint(1);
+
+        await expect(
+          contract.connect(minter)['safeTransferFrom(address,address,uint256)'](minter.address, receiverStub.address, 1)
+        ).to.be.reverted;
+      });
+    });
+  });
 });

--- a/test/ERC721S.burning.test.js
+++ b/test/ERC721S.burning.test.js
@@ -1,59 +1,52 @@
-const { expect } = require("chai");
-const { ethers } = require("hardhat");
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
 
-describe("ERC721S Burning", function () {
-    let contract;
-    let deployer;
-    let minter;
-    let approved;
+describe('ERC721S Burning', function () {
+  let contract;
+  let deployer;
+  let minter;
+  let approved;
 
-    beforeEach(async () => {
-        const ERC721SImpl = await ethers.getContractFactory("ERC721SImpl");
-        contract = await ERC721SImpl.deploy("ERC721Impl", "IMPL");
-        [deployer, minter, approved] = await ethers.getSigners();
+  beforeEach(async () => {
+    const ERC721SImpl = await ethers.getContractFactory('ERC721SImpl');
+    contract = await ERC721SImpl.deploy('ERC721Impl', 'IMPL');
+    [deployer, minter, approved] = await ethers.getSigners();
+  });
+
+  describe('burn', function () {
+    it('reverts if attemping to burn token that does not exist', async () => {
+      await expect(contract.burn(1)).to.be.reverted;
     });
 
-    describe("burn", function () {
-        it("reverts if attemping to burn token that does not exist", async () => {
-            await expect(contract.burn(1))
-                .to.be.reverted;
-        });
+    it('increments burnCount to adjust totalSupply correctly', async () => {
+      await contract.connect(minter).mint(1);
+      expect(await contract.totalSupply()).to.be.equal(1);
 
-        it("increments burnCount to adjust totalSupply correctly", async () => {
-            await contract.connect(minter).mint(1);
-            expect(await contract.totalSupply())
-                .to.be.equal(1);
-
-            await contract.burn(1);
-            expect(await contract.totalSupply())
-                .to.be.equal(0);
-        });
-
-        it("clears approved, reduces owner's balance, and sets new owner as address 0", async () => {
-            await contract.connect(minter).mint(1);
-            await contract.connect(minter).approve(approved.address, 1);
-
-            expect(await contract.getApproved(1))
-                .to.be.equal(approved.address);
-
-            await contract.burn(1);
-
-            expect(await contract.balanceOf(minter.address))
-                .to.be.equal(0);
-
-            await expect(contract.getApproved(1))
-                .to.be.revertedWith("ERC721: approved query for nonexistent token");
-
-            await expect(contract.ownerOf(1))
-                .to.be.revertedWith("ERC721: owner query for nonexistent token");
-        });
-
-        it("emits a transfer request to address 0", async () => {
-            await contract.connect(minter).mint(1);
-
-            await expect(contract.connect(minter).burn(1))
-                .to.emit(contract, "Transfer")
-                .withArgs(minter.address, ethers.constants.AddressZero, 1);
-        });
+      await contract.burn(1);
+      expect(await contract.totalSupply()).to.be.equal(0);
     });
+
+    it("clears approved, reduces owner's balance, and sets new owner as address 0", async () => {
+      await contract.connect(minter).mint(1);
+      await contract.connect(minter).approve(approved.address, 1);
+
+      expect(await contract.getApproved(1)).to.be.equal(approved.address);
+
+      await contract.burn(1);
+
+      expect(await contract.balanceOf(minter.address)).to.be.equal(0);
+
+      await expect(contract.getApproved(1)).to.be.revertedWith('ApprovedQueryForNonExistentToken');
+
+      await expect(contract.ownerOf(1)).to.be.revertedWith('OwnerQueryForNonExistentToken');
+    });
+
+    it('emits a transfer request to address 0', async () => {
+      await contract.connect(minter).mint(1);
+
+      await expect(contract.connect(minter).burn(1))
+        .to.emit(contract, 'Transfer')
+        .withArgs(minter.address, ethers.constants.AddressZero, 1);
+    });
+  });
 });

--- a/test/ERC721S.enumerable.test.js
+++ b/test/ERC721S.enumerable.test.js
@@ -30,7 +30,7 @@ describe("ERC721S Enumerable", function () {
         it("reverts if index is greater then the number of tokens associated with a given owner", async () => {
             await contract.connect(minter1).mint(1);
             await expect(contract.tokenOfOwnerByIndex(minter1.address, 1))
-                .to.be.revertedWith("ERC721Enumerable: owner index out of bounds");
+                .to.be.revertedWith('OwnerIndexOutOfBounds');
         });
     });
 

--- a/test/ERC721S.metadata.test.js
+++ b/test/ERC721S.metadata.test.js
@@ -1,51 +1,45 @@
-const { expect } = require("chai");
-const { ethers } = require("hardhat");
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
 
-describe("ERC721S Metadata", function () {
-    let contract;
-    let deployer;
-    let minter;
+describe('ERC721S Metadata', function () {
+  let contract;
+  let minter;
 
-    beforeEach(async () => {
-        const ERC721SImpl = await ethers.getContractFactory("ERC721SImpl");
-        contract = await ERC721SImpl.deploy("ERC721Impl", "IMPL");
-        [deployer, minter] = await ethers.getSigners();
+  beforeEach(async () => {
+    const ERC721SImpl = await ethers.getContractFactory('ERC721SImpl');
+    contract = await ERC721SImpl.deploy('ERC721Impl', 'IMPL');
+    [, minter] = await ethers.getSigners();
+  });
+
+  it('has a name', async () => {
+    expect(await contract.name()).to.be.equal('ERC721Impl');
+  });
+
+  it('has a symbol', async () => {
+    expect(await contract.symbol()).to.be.equal('IMPL');
+  });
+
+  describe('tokenURI', function () {
+    it('returns an empty string if no baseURI is set', async () => {
+      await contract.connect(minter).mint(1);
+
+      expect(await contract.tokenURI(1)).to.be.equal('');
     });
 
-    it("has a name", async () => {
-        expect(await contract.name()).to.be.equal("ERC721Impl");
+    it('reverts if given token id does not exist', async () => {
+      await expect(contract.tokenURI(1)).to.be.reverted;
     });
 
-    it("has a symbol", async () => {
-        expect(await contract.symbol()).to.be.equal("IMPL");
+    it('tokenURI can be updated by updating baseURI', async () => {
+      await contract.connect(minter).mint(1);
+
+      await contract.setBaseURI('https://example.org/token/v1/');
+
+      expect(await contract.tokenURI(1)).to.be.equal('https://example.org/token/v1/1');
+
+      await contract.setBaseURI('https://example.org/token/v2/');
+
+      expect(await contract.tokenURI(1)).to.be.equal('https://example.org/token/v2/1');
     });
-
-    describe("tokenURI", function () {
-        it("returns an empty string if no baseURI is set", async () => {
-            await contract.connect(minter).mint(1);
-
-            expect(await contract.tokenURI(1))
-                .to.be.equal("");
-        });
-
-        it("reverts if given token id does not exist", async () => {
-            await expect(contract.tokenURI(1))
-                .to.be.reverted;
-
-        });
-
-        it("tokenURI can be updated by updating baseURI", async () => {
-            await contract.connect(minter).mint(1);
-
-            await contract.setBaseURI("https://example.org/token/v1/");
-
-            expect(await contract.tokenURI(1))
-                .to.be.equal("https://example.org/token/v1/1");
-
-            await contract.setBaseURI("https://example.org/token/v2/");
-
-            expect(await contract.tokenURI(1))
-                .to.be.equal("https://example.org/token/v2/1");
-        });
-    });
+  });
 });

--- a/test/ERC721S.minting.test.js
+++ b/test/ERC721S.minting.test.js
@@ -1,94 +1,84 @@
-const { expect } = require("chai");
-const { ethers } = require("hardhat");
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
 
-describe("ERC721S Minting", function () {
-    let contract;
-    let deployer;
-    let minter;
+describe('ERC721S Minting', function () {
+  let contract;
+  let deployer;
+  let minter;
 
-    beforeEach(async () => {
-        const ERC721SImpl = await ethers.getContractFactory("ERC721SImpl");
-        contract = await ERC721SImpl.deploy("ERC721Impl", "IMPL");
-        [deployer, minter] = await ethers.getSigners();
+  beforeEach(async () => {
+    const ERC721SImpl = await ethers.getContractFactory('ERC721SImpl');
+    contract = await ERC721SImpl.deploy('ERC721Impl', 'IMPL');
+    [deployer, minter] = await ethers.getSigners();
+  });
+
+  describe('Minting', function () {
+    it("associates minted token with minter and increases the minter's balance", async () => {
+      await contract.connect(minter).mint(1);
+
+      expect(await contract.ownerOf(1)).to.be.equal(minter.address);
+      expect(await contract.balanceOf(minter.address)).to.be.equal(1);
     });
 
-    describe("Minting", function () {
-        it("associates minted token with minter and increases the minter's balance", async () => {
-            await contract.connect(minter).mint(1);
-
-            expect(await contract.ownerOf(1))
-                .to.be.equal(minter.address);
-            expect(await contract.balanceOf(minter.address))
-                .to.be.equal(1);
-        });
-
-        it("emits a transfer event on mint", async () => {
-            await expect(contract.connect(minter).mint(1))
-                .to.emit(contract, "Transfer")
-                .withArgs(ethers.constants.AddressZero, minter.address, 1);
-        });
-
-        it("cannot mint to address 0", async () => {
-            await expect(contract.mintToAddress(ethers.constants.AddressZero))
-                .to.be.revertedWith("ERC721: mint to the zero address");
-        });
+    it('emits a transfer event on mint', async () => {
+      await expect(contract.connect(minter).mint(1))
+        .to.emit(contract, 'Transfer')
+        .withArgs(ethers.constants.AddressZero, minter.address, 1);
     });
 
-    describe("Minting to a contract address", function () {
-        it("sucesfully mints to a contract address if receiving contract handles onERC721Received correctly", async () => {
-            const ERC721ValidReceiverStub = await ethers.getContractFactory("ERC721ValidReceiverStub");
-            receiverStub = await ERC721ValidReceiverStub.deploy();
-
-            await expect(contract.connect(minter).mintToAddress(receiverStub.address))
-                .to.emit(receiverStub, "Received")
-                .withArgs(minter.address, ethers.constants.AddressZero, 1, ethers.utils.toUtf8Bytes(""));
-
-            expect(await contract.ownerOf(1))
-                .to.be.equal(receiverStub.address);
-            expect(await contract.balanceOf(receiverStub.address))
-                .to.be.equal(1);
-        });
-
-        it("reverts if receiving contract does not have a onERC721Received function", async () => {
-            const ERC721EmptyReceiverStub = await ethers.getContractFactory("ERC721EmptyReceiverStub");
-            receiverStub = await ERC721EmptyReceiverStub.deploy();
-
-            await expect(contract.mintToAddress(receiverStub.address))
-                .to.be.revertedWith("ERC721: transfer to non ERC721Receiver implementer");
-        });
-
-        it("reverts if receiving contract reverts", async () => {
-            const ERC721RevertReceiverStub = await ethers.getContractFactory("ERC721RevertReceiverStub");
-            receiverStub = await ERC721RevertReceiverStub.deploy("");
-
-            await expect(contract.mintToAddress(receiverStub.address))
-                .to.be.reverted;
-        });
-
-        it("reverts with message if receiving contract reverts with a messasge", async () => {
-            const ERC721RevertReceiverStub = await ethers.getContractFactory("ERC721RevertReceiverStub");
-            receiverStub = await ERC721RevertReceiverStub.deploy("revert message");
-
-            await expect(contract.mintToAddress(receiverStub.address))
-                .to.be.revertedWith("revert message");
-        });
-
-        it("reverts if receiving contract returns an invalid response", async() => {
-            const ERC721InvalidReceiverStub = await ethers.getContractFactory("ERC721InvalidReceiverStub");
-            receiverStub = await ERC721InvalidReceiverStub.deploy();
-
-            await expect(contract.mintToAddress(receiverStub.address))
-                .to.be.reverted;
-
-        });
-
-        it("reverts if receiving contract panics", async() => {
-            const ERC721PanicReceiverStub = await ethers.getContractFactory("ERC721PanicReceiverStub");
-            receiverStub = await ERC721PanicReceiverStub.deploy();
-
-            await expect(contract.mintToAddress(receiverStub.address))
-                .to.be.reverted;
-
-        });
+    it('cannot mint to address 0', async () => {
+      await expect(contract.mintToAddress(ethers.constants.AddressZero)).to.be.revertedWith('MintToTheZeroAddress');
     });
+  });
+
+  describe('Minting to a contract address', function () {
+    it('sucesfully mints to a contract address if receiving contract handles onERC721Received correctly', async () => {
+      const ERC721ValidReceiverStub = await ethers.getContractFactory('ERC721ValidReceiverStub');
+      receiverStub = await ERC721ValidReceiverStub.deploy();
+
+      await expect(contract.connect(minter).mintToAddress(receiverStub.address))
+        .to.emit(receiverStub, 'Received')
+        .withArgs(minter.address, ethers.constants.AddressZero, 1, ethers.utils.toUtf8Bytes(''));
+
+      expect(await contract.ownerOf(1)).to.be.equal(receiverStub.address);
+      expect(await contract.balanceOf(receiverStub.address)).to.be.equal(1);
+    });
+
+    it('reverts if receiving contract does not have a onERC721Received function', async () => {
+      const ERC721EmptyReceiverStub = await ethers.getContractFactory('ERC721EmptyReceiverStub');
+      receiverStub = await ERC721EmptyReceiverStub.deploy();
+
+      await expect(contract.mintToAddress(receiverStub.address)).to.be.revertedWith(
+        'TransferToNonERC721ReceiverImplementer'
+      );
+    });
+
+    it('reverts if receiving contract reverts', async () => {
+      const ERC721RevertReceiverStub = await ethers.getContractFactory('ERC721RevertReceiverStub');
+      receiverStub = await ERC721RevertReceiverStub.deploy('');
+
+      await expect(contract.mintToAddress(receiverStub.address)).to.be.reverted;
+    });
+
+    it('reverts with message if receiving contract reverts with a messasge', async () => {
+      const ERC721RevertReceiverStub = await ethers.getContractFactory('ERC721RevertReceiverStub');
+      receiverStub = await ERC721RevertReceiverStub.deploy('revert message');
+
+      await expect(contract.mintToAddress(receiverStub.address)).to.be.revertedWith('revert message');
+    });
+
+    it('reverts if receiving contract returns an invalid response', async () => {
+      const ERC721InvalidReceiverStub = await ethers.getContractFactory('ERC721InvalidReceiverStub');
+      receiverStub = await ERC721InvalidReceiverStub.deploy();
+
+      await expect(contract.mintToAddress(receiverStub.address)).to.be.reverted;
+    });
+
+    it('reverts if receiving contract panics', async () => {
+      const ERC721PanicReceiverStub = await ethers.getContractFactory('ERC721PanicReceiverStub');
+      receiverStub = await ERC721PanicReceiverStub.deploy();
+
+      await expect(contract.mintToAddress(receiverStub.address)).to.be.reverted;
+    });
+  });
 });

--- a/test/ERC721S.misc.test.js
+++ b/test/ERC721S.misc.test.js
@@ -1,74 +1,67 @@
-const { expect } = require("chai");
-const { ethers } = require("hardhat");
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
 
-describe("ERC721S Misc", function () {
-    let contract;
-    let deployer;
-    let minter1;
-    let minter2;
+describe('ERC721S Misc', function () {
+  let contract;
+  let deployer;
+  let minter1;
+  let minter2;
 
-    beforeEach(async () => {
-        const ERC721SImpl = await ethers.getContractFactory("ERC721SImpl");
-        contract = await ERC721SImpl.deploy("ERC721Impl", "IMPL");
-        [deployer, minter1, minter2] = await ethers.getSigners();
+  beforeEach(async () => {
+    const ERC721SImpl = await ethers.getContractFactory('ERC721SImpl');
+    contract = await ERC721SImpl.deploy('ERC721Impl', 'IMPL');
+    [deployer, minter1, minter2] = await ethers.getSigners();
+  });
+
+  describe('balanceOf', function () {
+    it('returns number of tokens associated with address', async () => {
+      expect(await contract.balanceOf(minter1.address)).to.be.equal(0);
+
+      await contract.connect(minter1).mint(2);
+
+      expect(await contract.balanceOf(minter1.address)).to.be.equal(2);
     });
 
-    describe("balanceOf", function () {
-        it("returns number of tokens associated with address", async () => {
-            expect(await contract.balanceOf(minter1.address))
-                .to.be.equal(0);
+    it('reverts when attempting to get balance of address 0x0', async () => {
+      await expect(contract.balanceOf(ethers.constants.AddressZero)).to.be.revertedWith('BalanceQueryForZeroAddress');
+    });
+  });
 
-            await contract.connect(minter1).mint(2);
+  describe('ownerOf', function () {
+    it("returns the owner's address when providing a token id", async () => {
+      await contract.connect(minter1).mint(1);
+      await contract.connect(minter2).mint(1);
 
-            expect(await contract.balanceOf(minter1.address))
-                .to.be.equal(2);
-        });
+      expect(await contract.ownerOf(1)).to.be.equal(minter1.address);
 
-        it("reverts when attempting to get balance of address 0x0", async () => {
-            await expect(contract.balanceOf(ethers.constants.AddressZero))
-                .to.be.revertedWith("ERC721: balance query for the zero address");
-        });
+      expect(await contract.ownerOf(2)).to.be.equal(minter2.address);
     });
 
-    describe("ownerOf", function () {
-        it("returns the owner's address when providing a token id", async () => {
-            await contract.connect(minter1).mint(1);
-            await contract.connect(minter2).mint(1);
+    it('reverts when attempting to get ownerOf a nonexistant token', async () => {
+      await expect(contract.ownerOf(0)).to.be.reverted;
+      await expect(contract.ownerOf(1)).to.be.reverted;
+    });
+  });
 
-            expect(await contract.ownerOf(1))
-                .to.be.equal(minter1.address);
-
-            expect(await contract.ownerOf(2))
-                .to.be.equal(minter2.address);
-        });
-
-        it("reverts when attempting to get ownerOf a nonexistant token", async () => {
-            await expect(contract.ownerOf(0))
-                .to.be.reverted;
-            await expect(contract.ownerOf(1))
-                .to.be.reverted;
-        });
+  describe('supportsInterface', function () {
+    it('returns true for ERC721', async () => {
+      const erc721InterfaceId = 0x80ac58cd;
+      expect(await contract.supportsInterface(erc721InterfaceId)).to.be.equal(true);
     });
 
-    describe("supportsInterface", function () {
-        it("returns true for ERC721", async() => {
-            const erc721InterfaceId = 0x80ac58cd;
-            expect(await contract.supportsInterface(erc721InterfaceId)).to.be.equal(true);
-        });
-
-        it("returns true for ERC721-metadata", async() => {
-            const erc721MetadataInterfaceId = 0x5b5e139f;
-            expect(await contract.supportsInterface(erc721MetadataInterfaceId)).to.be.equal(true);
-        });
-
-        it("returns true for ERC165", async() => {
-            const erc165InterfaceId = 0x01ffc9a7
-            expect(await contract.supportsInterface(erc165InterfaceId)).to.be.equal(true);
-        });
-
-        it("returns false for invalid id", async() => {
-            const erc165InterfaceId = 0x01ffc9a7
-            expect(await contract.supportsInterface(0xffffffff)).to.be.equal(false);
-        });
+    it('returns true for ERC721-metadata', async () => {
+      const erc721MetadataInterfaceId = 0x5b5e139f;
+      expect(await contract.supportsInterface(erc721MetadataInterfaceId)).to.be.equal(true);
     });
+
+    it('returns true for ERC165', async () => {
+      const erc165InterfaceId = 0x01ffc9a7;
+      expect(await contract.supportsInterface(erc165InterfaceId)).to.be.equal(true);
+    });
+
+    it('returns false for invalid id', async () => {
+      const erc165InterfaceId = 0x01ffc9a7;
+      expect(await contract.supportsInterface(0xffffffff)).to.be.equal(false);
+    });
+  });
 });


### PR DESCRIPTION
In the spirit of the "Ugh. I HATE GAS!!" sentiment, I have a pull request ready that uses custom errors to save on gas at deploy time. It looks like it'll save ~13% on the ERC721SImpl deployment.

The strings in the require's cost gas and rewriting the checks (there are quite a few) to use custom errors will trim the amount of gas used on deployment.

e.g. Changing...

``` solidity
 require(owner != address(0), "ERC721: balance query for the zero address");
```

to 

``` solidity
error BalanceQueryForZeroAddress();

...

if (owner == address(0)) {
    revert BalanceQueryForZeroAddress();
}
```